### PR TITLE
DEV-15524 Making AutoBind adapter configurable to accept document parts

### DIFF
--- a/src/adapters/AdapterInterface.ts
+++ b/src/adapters/AdapterInterface.ts
@@ -2,6 +2,7 @@ import {Match, MatchWithReplacement, Check, CheckResult, DocumentSelection} from
 
 export interface CommonAdapterConf {
   scrollOffsetY?: number;
+  documentPart?: Document[];
 }
 
 export interface HasEditorID extends CommonAdapterConf {

--- a/src/autobind/autobind.ts
+++ b/src/autobind/autobind.ts
@@ -42,12 +42,15 @@ function isProbablySearchField(el: HTMLElement) {
   return _.includes(PROBABLE_SEARCH_FIELD_NAMES, el.getAttribute('name')) && isAutoCompleteOff(el);
 }
 
-function getEditableElements(doc: Document = document): HTMLElement[] {
-  const visibleElements: HTMLElement[] = _.filter((doc.querySelectorAll(EDITABLE_ELEMENTS_SELECTOR) as any) as List<HTMLElement>, isDisplayed) as HTMLElement[];
+function getEditableElements(doc: Document[] = [document]): HTMLElement[] {
+  let visibleElements: HTMLElement[] = [];
+  doc.forEach(element => {
+    visibleElements.push(..._.filter((element.querySelectorAll(EDITABLE_ELEMENTS_SELECTOR) as any) as List<HTMLElement>, isDisplayed) as HTMLElement[]);
+  });
   return _(visibleElements).flatMap((el: HTMLElement) => {
     if (isIFrame(el)) {
       try {
-        return el.contentDocument ? getEditableElements(el.contentDocument) : [];
+        return el.contentDocument ? getEditableElements([el.contentDocument]) : [];
       } catch (err) {
         // Caused by same origin policy problems.
         return [];


### PR DESCRIPTION
Hi Marco, Ralf
I have created this request to make Autobind adapter configurable to accept document parts. In Drupal Autobind adapter helps us to get all the fields from a node, but there are some fields we want to exclude(like revision log messages,).
I made the changes to Autobind adapter so it can accept an array of document parts and extract HTMLElements from it to create single adapters.
Could you please have a look at the request and let me know if its a good approach?