### PR TITLE
Export floating sidebar, make sidebarContainer id configurable

### DIFF
--- a/src/acrolinx-sidebar-integration.ts
+++ b/src/acrolinx-sidebar-integration.ts
@@ -33,11 +33,15 @@ import {getSelectionHtmlRanges} from "./utils/range";
 import {lookupMatches} from "./lookup/diff-based";
 import {extractTextDomMapping} from "./utils/text-dom-mapping";
 import {CodeMirrorAdapter} from "./adapters/CodeMirrorAdapter";
+import {initFloatingSidebar} from "./floating-sidebar/floating-sidebar";
+import {AsyncLocalStorage} from "./floating-sidebar/async-storage";
 
 
 export interface AcrolinxSidebarIntegration {
   AcrolinxPlugin: typeof AcrolinxPlugin;
   autoBindFloatingSidebar: typeof autoBindFloatingSidebar;
+  initFloatingSidebar: typeof initFloatingSidebar;
+  AsyncLocalStorage: typeof AsyncLocalStorage;
   createPluginMessageAdapter: typeof createPluginMessageAdapter;
   loadSidebarCode: typeof loadSidebarCode;
   getSelectionHtmlRanges: typeof getSelectionHtmlRanges;
@@ -74,6 +78,8 @@ const exported: AcrolinxSidebarIntegration = {
   AcrolinxPlugin: AcrolinxPlugin,
   autoBindFloatingSidebar: autoBindFloatingSidebar,
   createPluginMessageAdapter: createPluginMessageAdapter,
+  initFloatingSidebar: initFloatingSidebar,
+  AsyncLocalStorage: AsyncLocalStorage,
   loadSidebarCode: loadSidebarCode,
   getSelectionHtmlRanges: getSelectionHtmlRanges,
   adapter: {

--- a/src/floating-sidebar/floating-sidebar.ts
+++ b/src/floating-sidebar/floating-sidebar.ts
@@ -5,7 +5,7 @@ import {AsyncStorage} from "./async-storage";
 export const SIDEBAR_ID = 'acrolinxFloatingSidebar';
 export const TITLE_BAR_CLASS = 'acrolinxFloatingSidebarTitleBar';
 export const CLOSE_ICON_CLASS = 'acrolinxFloatingSidebarCloseIcon';
-export const SIDEBAR_CONTAINER_ID = 'acrolinxSidebarContainer';
+export let SIDEBAR_CONTAINER_ID = 'acrolinxSidebarContainer';
 export const SIDEBAR_DRAG_OVERLAY_ID = 'acrolinxDragOverlay';
 export const SIDEBAR_GLASS_PANE_ID = 'acrolinxFloatingSidebarGlassPane';
 export const FOOTER = 'acrolinxFloatingSidebarFooter';
@@ -212,7 +212,8 @@ function addStyles() {
   head.appendChild(styleTag);
 }
 
-const TEMPLATE = `
+function createTemplate() : string {
+  return `
     <div id="${SIDEBAR_ID}">
       <div class="${TITLE_BAR_CLASS}">Acrolinx <span class="${CLOSE_ICON_CLASS}" title="Hide"></span></div>
       <div id="${SIDEBAR_CONTAINER_ID}"></div>
@@ -220,6 +221,7 @@ const TEMPLATE = `
       <div class="${FOOTER}"><div class="${RESIZE_ICON_CLASS}" title="Drag to resize"></div></div>
     </div>
   `;
+}
 
 function createDiv(attributes: {[attribute: string]: string}): HTMLElement {
   const el = document.createElement('div');
@@ -246,11 +248,17 @@ export interface FloatingSidebar {
 
 export interface FloatingSidebarConfig {
   asyncStorage: AsyncStorage;
+  sidebarContainerId?: string;
 }
 
 export function initFloatingSidebar(config: FloatingSidebarConfig): FloatingSidebar {
+  if (config.sidebarContainerId) {
+    SIDEBAR_CONTAINER_ID = config.sidebarContainerId;
+  }
+
   let position = DEFAULT_POS;
-  const floatingSidebarElement = createNodeFromTemplate(TEMPLATE);
+  const template = createTemplate();
+  const floatingSidebarElement = createNodeFromTemplate(template);
   const dragOverlay = floatingSidebarElement.querySelector('#' + SIDEBAR_DRAG_OVERLAY_ID) as HTMLElement;
   const closeIcon = floatingSidebarElement.querySelector('.' + CLOSE_ICON_CLASS) as HTMLElement;
   const resizeIcon = floatingSidebarElement.querySelector('.' + RESIZE_ICON_CLASS) as HTMLElement;


### PR DESCRIPTION
Hi Marco, Ralf,

Created this request for exporting floating sidebar
**Changes:**
1. Exported floatingSidebar and AsyncLocalStorage.
2. Made sidebarContainerId configurable, 
Approach: 
1. Changed sidebarContainerId declaration from const to let.
2. Changed TEMPLATE const to createTemplate function.

Other approach I and @pcdeshmukh thought for sidebarContainerId
1. Generating randomIdentifier for container id like "acrolinxSidebarContainer" + randomnumber
Somehow, we had a feeling that this id should be generated by the floating sidebar itself as it is independent entity and doesn't directly depend upon DOM
2. If randomidentifier is generated by floating sidebar either it need to be exported or injected in the config

Please review the changes and let me know if this approach is ok or suggestions for improvements.


                   

