### PR TITLE
DEV-15242 Using scrollIntoView from scrolling utils in Ckeditor adapter

### DIFF
--- a/src/adapters/CKEditorAdapter.ts
+++ b/src/adapters/CKEditorAdapter.ts
@@ -21,6 +21,7 @@
 import {Match, MatchWithReplacement} from "../acrolinx-libs/plugin-interfaces";
 import {AbstractRichtextEditorAdapter} from "./AbstractRichtextEditorAdapter";
 import {HasEditorID, ContentExtractionResult} from "./AdapterInterface";
+import { scrollIntoView } from "../utils/scrolling";
 
 
 export class CKEditorAdapter extends AbstractRichtextEditorAdapter {
@@ -79,5 +80,9 @@ export class CKEditorAdapter extends AbstractRichtextEditorAdapter {
 
   isInWysiwygMode() {
     return this.getEditor().mode === 'wysiwyg';
+  }
+
+  protected scrollElementIntoView(el: HTMLElement) {
+    scrollIntoView(el, this.config.scrollOffsetY);
   }
 }


### PR DESCRIPTION
Hi Marco, Ralf
The configurable "y-offset" scrolling will be required in CKEditor adapter also.
In DEV-15242 I have added a video about the issue with current CKEditor scrolling.
Drupal has a persistent toolbar and the element need to be scrolled below an approximate offset. 

I have overridden the "scrollElementIntoView" method from Abstract RTE adapter and used scrollIntoView from scrolling utils.

I didn't this changes in Abstract RTE as it might be required to be implemented differently in some other adapter.

Please review the changes and let me know if they are ok? Or suggestions for improvement. 