### PR TITLE
Use ubuntu-22.04 in build job due to a bug in setup-chrome action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       testserver_username: ${{ secrets.testserver_username }}
       testserver_password: ${{ secrets.testserver_password }}


### PR DESCRIPTION
See https://github.com/browser-actions/setup-chrome/issues/618